### PR TITLE
fix: GeoIP no longer exists in RHEL9

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,10 @@ _goaccess_dependency_packages:
     - geoip-devel
     - libmaxminddb-devel
     - openssl-devel
+  RedHat_9:
+    - ncurses-devel
+    - libmaxminddb
+    - openssl-devel
   Arch:
     - ncurses
     - geoip


### PR DESCRIPTION
or, at least this alteration is needed for Rocky Linux 9

libmaxminddb (which still exists) is GeoIP2 (as per https://github.com/allinurl/goaccess#distribution-packages), so the missing of just GeoIP should be fine

Fixes #44

<!-- Insert Description here, if any. -->

## **Pull Request Checklist**

- [x] I am a nice guy <!-- the 'too long; did not read;' of the CODE_OF_CONDUCT.md -->
- [x] This pull request and its commits address only a single concern
- [[-documentation of this is generic-](https://github.com/JonasPammer/ansible-role-goaccess/blob/beb83aed14fffbe9d52a53e0e6cf2f96c6c823ea/README.orig.adoc?plain=1#L65)] Documentation has been altered or extended appropriately

- [ ] I have followed [JonasPammer's Ansible Role Development Guidelines](https://github.com/JonasPammer/cookiecutter-ansible-role/blob/master/ROLE_DEVELOPMENT_GUIDELINES.adoc)

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No - because RHEL source installs were already not working it changes nothing in this matter.
its only odd that i named the variable like that and install it no matter the method. may have misread the documentation when implementing it. might make a breaking PR to fix this situation.