### PR TITLE
refactor!: only install additional packages when source installing

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -92,13 +92,6 @@ must be installed on the Ansible controller.
 
 [source,yaml]
 ----
-goaccess_dependency_packages: [OS-dependant by default, see /defaults directory]
-----
-List of packages to install from the system's package manager.
-See https://github.com/allinurl/goaccess#distribution-packages[GoAccess Official Documentation] for reference.
-
-[source,yaml]
-----
 goaccess_install_method: "{{ 'source' if ansible_os_family != 'RedHat' else 'system' }}"
 ----
 One of "`source`" or "`system`".
@@ -182,9 +175,22 @@ The goaccess version string to check against.
 
 [source,yaml]
 ----
-goaccess_source_dependency_packages: [OS-dependant by default, see /defaults directory]
+goaccess_source_buildtool_packages: [OS-dependant by default, see /defaults directory]
 ----
-List of packages to install from the system's package manager.
+List of packages needed for building GoAccess from source
+(`gcc`, `autoconf`, `gettext`, `autopoint` etc)
+which will be installed using the system's package manager.
+
+
+[source,yaml]
+----
+goaccess_source_system_packages: [OS-dependant by default, see /defaults directory]
+----
+List of dependencies needed in some distros to build GoAccess from source
+(`NCurses` (required), `GeoIP` / `GeoIP2` (optional), `OpenSSL` (optional))
+which will be installed using the system's package manager.
+The default value of this mostly represents
+https://github.com/allinurl/goaccess#distribution-packages[the table found in the official documentation].
 
 [source,yaml]
 ----

--- a/README.md
+++ b/README.md
@@ -71,10 +71,6 @@ The [`community.general` collection](https://galaxy.ansible.com/community/genera
 
 # 📜 Role Variables
 
-    goaccess_dependency_packages: [OS-dependant by default, see /defaults directory]
-
-List of packages to install from the system’s package manager. See [GoAccess Official Documentation](https://github.com/allinurl/goaccess#distribution-packages) for reference.
-
     goaccess_install_method: "{{ 'source' if ansible_os_family != 'RedHat' else 'system' }}"
 
 One of “source” or “system”.
@@ -127,9 +123,13 @@ The [git version](https://github.com/allinurl/goaccess/tags) to download.
 
 The goaccess version string to check against.
 
-    goaccess_source_dependency_packages: [OS-dependant by default, see /defaults directory]
+    goaccess_source_buildtool_packages: [OS-dependant by default, see /defaults directory]
 
-List of packages to install from the system’s package manager.
+List of packages needed for building GoAccess from source (`gcc`, `autoconf`, `gettext`, `autopoint` etc) which will be installed using the system’s package manager.
+
+    goaccess_source_system_packages: [OS-dependant by default, see /defaults directory]
+
+List of dependencies needed in some distros to build GoAccess from source (`NCurses` (required), `GeoIP` / `GeoIP2` (optional), `OpenSSL` (optional)) which will be installed using the system’s package manager. The default value of this mostly represents [the table found in the official documentation](https://github.com/allinurl/goaccess#distribution-packages).
 
     goaccess_source_configure_parameters: "--enable-utf8 --enable-geopip=mmdb"
 

--- a/README.orig.adoc
+++ b/README.orig.adoc
@@ -62,13 +62,6 @@ must be installed on the Ansible controller.
 
 [source,yaml]
 ----
-goaccess_dependency_packages: [OS-dependant by default, see /defaults directory]
-----
-List of packages to install from the system's package manager.
-See https://github.com/allinurl/goaccess#distribution-packages[GoAccess Official Documentation] for reference.
-
-[source,yaml]
-----
 goaccess_install_method: "{{ 'source' if ansible_os_family != 'RedHat' else 'system' }}"
 ----
 One of "`source`" or "`system`".
@@ -152,9 +145,22 @@ The goaccess version string to check against.
 
 [source,yaml]
 ----
-goaccess_source_dependency_packages: [OS-dependant by default, see /defaults directory]
+goaccess_source_buildtool_packages: [OS-dependant by default, see /defaults directory]
 ----
-List of packages to install from the system's package manager.
+List of packages needed for building GoAccess from source
+(`gcc`, `autoconf`, `gettext`, `autopoint` etc)
+which will be installed using the system's package manager.
+
+
+[source,yaml]
+----
+goaccess_source_system_packages: [OS-dependant by default, see /defaults directory]
+----
+List of dependencies needed in some distros to build GoAccess from source
+(`NCurses` (required), `GeoIP` / `GeoIP2` (optional), `OpenSSL` (optional))
+which will be installed using the system's package manager.
+The default value of this mostly represents
+https://github.com/allinurl/goaccess#distribution-packages[the table found in the official documentation].
 
 [source,yaml]
 ----

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,33 @@
 goaccess_install_method: "{{ 'source' if ansible_os_family != 'RedHat' else 'system' }}"
 goaccess_command_dir: "{{ '/usr/local/bin' if goaccess_install_method == 'source' else '/usr/bin' }}"
 
-_goaccess_dependency_packages:
+### Variables used by system installation method ###
+goaccess_system_install_official_repo: true
+goaccess_system_package_state: present
+
+### Variables used by source installation method ###
+goaccess_source_version: v1.6
+goaccess_version: "{{ goaccess_source_version | replace('v', '') }}"
+_goaccess_source_buildtool_packages:
+  Debian:
+    - gettext
+    - build-essential
+    - dh-autoreconf
+  RedHat:
+    - "@Development Tools"
+    - autoconf
+    - gettext-devel
+  Arch:
+    - "autoconf"
+goaccess_source_buildtool_packages: "{{
+  _goaccess_source_buildtool_packages[ansible_distribution ~ '_' ~ ansible_distribution_major_version]|default(
+  _goaccess_source_buildtool_packages[ansible_os_family ~ '_' ~ ansible_distribution_major_version])|default(
+  _goaccess_source_buildtool_packages[ansible_distribution])|default(
+  _goaccess_source_buildtool_packages[ansible_os_family])|default(
+  _goaccess_source_buildtool_packages['default']) }}"
+goaccess_source_configure_parameters: "--enable-utf8 --enable-geopip=mmdb"
+
+_goaccess_source_system_packages:
   Debian:
     - libncursesw5-dev
     - libgeoip-dev
@@ -35,38 +61,12 @@ _goaccess_dependency_packages:
     - GeoIP
     - libmaxminddb
     - openssl
-goaccess_dependency_packages: "{{
-  _goaccess_dependency_packages[ansible_distribution ~ '_' ~ ansible_distribution_major_version]|default(
-  _goaccess_dependency_packages[ansible_os_family ~ '_' ~ ansible_distribution_major_version])|default(
-  _goaccess_dependency_packages[ansible_distribution])|default(
-  _goaccess_dependency_packages[ansible_os_family])|default(
-  _goaccess_dependency_packages['default']) }}"
-
-### Variables used by system installation method ###
-goaccess_system_install_official_repo: true
-goaccess_system_package_state: present
-
-### Variables used by source installation method ###
-goaccess_source_version: v1.6
-goaccess_version: "{{ goaccess_source_version | replace('v', '') }}"
-_goaccess_source_dependency_packages:
-  Debian:
-    - gettext
-    - build-essential
-    - dh-autoreconf
-  RedHat:
-    - "@Development Tools"
-    - autoconf
-    - gettext-devel
-  Arch:
-    - "autoconf"
-goaccess_source_dependency_packages: "{{
-  _goaccess_source_dependency_packages[ansible_distribution ~ '_' ~ ansible_distribution_major_version]|default(
-  _goaccess_source_dependency_packages[ansible_os_family ~ '_' ~ ansible_distribution_major_version])|default(
-  _goaccess_source_dependency_packages[ansible_distribution])|default(
-  _goaccess_source_dependency_packages[ansible_os_family])|default(
-  _goaccess_source_dependency_packages['default']) }}"
-goaccess_source_configure_parameters: "--enable-utf8 --enable-geopip=mmdb"
+goaccess_source_system_packages: "{{
+  _goaccess_source_system_packages[ansible_distribution ~ '_' ~ ansible_distribution_major_version]|default(
+  _goaccess_source_system_packages[ansible_os_family ~ '_' ~ ansible_distribution_major_version])|default(
+  _goaccess_source_system_packages[ansible_distribution])|default(
+  _goaccess_source_system_packages[ansible_os_family])|default(
+  _goaccess_source_system_packages['default']) }}"
 
 ### Variables for generating systemd service configuration file ###
 goaccess_systemd: false

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -2,12 +2,12 @@
 # tasks file for testing that variables of ansible-role jonaspammer.goaccess are set correctly
 # https://docs.ansible.com/ansible/latest/user_guide/playbooks_tests.html
 
-- name: test if goaccess_dependency_packages is set correctly
+- name: test if goaccess_source_system_packages is set correctly
   ansible.builtin.assert:
     that:
-      - goaccess_dependency_packages is defined
-      - goaccess_dependency_packages is string or
-        goaccess_dependency_packages is iterable
+      - goaccess_source_system_packages is defined
+      - goaccess_source_system_packages is string or
+        goaccess_source_system_packages is iterable
     quiet: true
 
 - name: test if goaccess_install_method is set correctly
@@ -30,11 +30,11 @@
       - goaccess_source_version is string
     quiet: true
 
-- name: test if goaccess_source_dependency_packages is set correctly
+- name: test if goaccess_source_buildtool_packages is set correctly
   ansible.builtin.assert:
     that:
-      - goaccess_source_dependency_packages is iterable or
-        goaccess_source_dependency_packages is string
+      - goaccess_source_buildtool_packages is iterable or
+        goaccess_source_buildtool_packages is string
     quiet: true
 
 ### Role Variables for creating a GoAccess Configuration File ###

--- a/tasks/install-from_source.yml
+++ b/tasks/install-from_source.yml
@@ -2,9 +2,14 @@
 # tasks file of ansible-role jonaspammer.goaccess
 # only included when needed
 
-- name: Install System Packages needed for Source Compilation.
+- name: Install Essential System Packages needed for building GoAccess from source.
   ansible.builtin.package:
-    name: "{{ goaccess_source_dependency_packages }}"
+    name: "{{ goaccess_source_buildtool_packages }}"
+    state: present
+
+- name: Install System Packages needed on some distros for building GoAccess from source.
+  ansible.builtin.package:
+    name: "{{ goaccess_source_system_packages }}"
     state: present
 
 - name: generate temporary directory for downloading goaccess source files

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,11 +6,6 @@
   run_once: true
   delegate_to: localhost
 
-- name: Install GoAccess dependencies (including optional ones)
-  ansible.builtin.package:
-    name: "{{ goaccess_dependency_packages }}"
-    state: present
-
 - name: get current goaccess version # noqa risky-shell-pipe
   ansible.builtin.shell: >
     goaccess --version |


### PR DESCRIPTION
as per note made in https://github.com/JonasPammer/ansible-role-goaccess/pull/45#issue-1708161508 i also renamed variables so their content is more clear and fitting with the official goaccess docs

Fixes #

<!-- Insert Description here, if any. -->

## **Pull Request Checklist**

- [x] I am a nice guy <!-- the 'too long; did not read;' of the CODE_OF_CONDUCT.md -->
- [x] This pull request and its commits address only a single concern
- [x] Documentation has been altered or extended appropriately

- [ ] I have followed [JonasPammer's Ansible Role Development Guidelines](https://github.com/JonasPammer/cookiecutter-ansible-role/blob/master/ROLE_DEVELOPMENT_GUIDELINES.adoc)

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

YES!

`goaccess_source_dependency_packages` was renamed to `goaccess_source_buildtool_packages`

`goaccess_dependency_packages` was renamed to `goaccess_source_system_packages`